### PR TITLE
feat: Adding fake GPS data option to GTU7 module for issue 104

### DIFF
--- a/python/raspberrypico/drivers/src/gtu7.py
+++ b/python/raspberrypico/drivers/src/gtu7.py
@@ -1,4 +1,4 @@
-import utime, time, math
+import utime, time, random
 
 class GTU7 :
     """GT-U7 driver for capturing GPS data."""
@@ -10,13 +10,15 @@ class GTU7 :
         self.timeout = 8 # total length of time in seconds to poll for GPS data
 
         
-    def gpgga(self, timeout=None) :
+    def gpgga(self, timeout=None, fake=False) :
         """Get GPS GPGGA data
 
         Parameters
         ----------
         timeout : int, optional
             The total length of time in seconds to poll for GPS data
+        fake : boolean, optional
+            Return fake data. Useful if GPS signal is not available
 
         Returns
         -------
@@ -29,17 +31,20 @@ class GTU7 :
         timeout_e = time.time() + timeout
         
         while True:
+            if fake :
+                return [self.__stringifyFakeTime(utime.localtime(time.time())),
+                        4026.774,
+                        -8902.08,
+                        random.randint(6,9)]
+            
             self.buff = str(self.uart.readline())
             parts = self.buff.split(',')
             
             # Example GPGGA (http://aprs.gids.nl/nmea/#gga)
             # $GPGGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx*hh
-            # https://latlongdata.com/lat-long-converter/
             if (parts[0] == "b'$GPGGA" and len(parts) == 15) :
-                #print(parts)
                 try:
-                    #latitude = self.__convertToDegree(parts[2])
-                    latitude = parts[2]
+                    latitude = self.__convertToDegree(parts[2])
                 except:
                     latitude = parts[2]
 
@@ -47,8 +52,7 @@ class GTU7 :
                     latitude = '-' + latitude
 
                 try:
-                    #longitude = self.__convertToDegree(parts[4])
-                    longitude = parts[4]
+                    longitude = self.__convertToDegree(parts[4])
                 except:
                     longitude = parts[4]
 
@@ -66,13 +70,15 @@ class GTU7 :
             if (time.time() > timeout_e) :
                 return []
             
-    def gprmc(self, timeout=None) :
+    def gprmc(self, timeout=None, fake=False) :
         """Get GPS GPRMC data
 
         Parameters
         ----------
         timeout : int, optional
             The total length of time in seconds to poll for GPS data
+        fake : boolean, optional
+            Return fake data. Useful if GPS signal is not available
 
         Returns
         -------
@@ -85,6 +91,13 @@ class GTU7 :
         timeout_e = time.time() + timeout
         
         while True:
+            if fake :
+                return [self.__stringifyFakeDate(utime.localtime(time.time())),
+                        self.__stringifyFakeTime(utime.localtime(time.time())),
+                        4026.774,
+                        -8902.08,
+                        round(random.uniform(0.0,0.1),3)]
+            
             self.buff = str(self.uart.readline())
             parts = self.buff.split(',')
             
@@ -123,13 +136,14 @@ class GTU7 :
                 return []
     
     
-    def __convertToDegree(self, ddm) :
-        degrees = math.floor(ddm / 100)
-        minutes = ddm - degrees * 100
-        dd = degrees + minutes / 60.0
-        dd = '{0:.6f}'.format(dd)
+    def __convertToDegree(self, degrees) :
+        firstdigits = int(degrees / 100) 
+        nexttwodigits = degrees - float(firstdigits * 100) 
+
+        converted = float(firstdigits + nexttwodigits / 60.0)
+        converted = '{0:.6f}'.format(converted)
         
-        return str(dd)
+        return str(converted)
 
 
     def __stringifyGpsTime(self, t) :
@@ -144,60 +158,15 @@ class GTU7 :
             return d[0:2] + "-" + d[2:4] + "-" + d[4:6]
         else :
             return ''
+        
+    def __stringifyFakeTime(self, t) :
+        if t :
+            return str(t[3]) + ":" + str(t[4]) + ":" + str(t[5])
+        else :
+            return ''
 
-    def sendUBX(self, msg):
-        self.uart.flush()
-        self.uart.write(bytes([0xFF]))
-        time.sleep_ms(100)
-        #for c in msg:
-        #print(str(type(msg)))
-        self.uart.write(msg)
-                      
-    def getUBX_ACK(self, msg): 
-        startTime = time.ticks_ms()
-        ackByteId = 0
-        
-        # Construct the expected ACK packet    
-        ackPacket = bytearray([0xB5, 0x62, 0x05, 0x01, 0x02, 0x00, msg[2], msg[3], 0x00, 0x00])
-      
-        # Calculate the checksums THIS IS NOT CALCULATING RIGHT
-        for u in range (2, 8):
-            ackPacket[8] = ackPacket[8] + ackPacket[u]
-            ackPacket[9] = ackPacket[9] + ackPacket[8]
-       
-        while True:
-            # Test for success
-            if ackByteId > 9:
-                # All bytes in order!
-                return True
-            
-            # Timeout if no valid response in 3 seconds
-            if time.ticks_diff(startTime, time.ticks_ms()) > 3000:
-                return false
-            
-            # Make sure data is available to read
-            if self.uart.any():
-                b = self.uart.read(1)
-                
-                # Check that bytes arrive in sequence as per expected ACK packet
-                if b[0] == ackPacket[ackByteId]:
-                    ackByteId = ackByteId + 1
-                else:
-                    # Reset and look again, invalid order
-                    ackByteId = 0
-        
-    def resetGPS(self):
-        set_reset = bytes([0xB5, 0x62, 0x06, 0x04, 0x04, 0x00, 0xFF, 0x87, 0x00, 0x00, 0x94, 0xF5])
-        self.sendUBX(set_reset)
-
-    def setGPS_DynamicMode6(self):
-        set_dm6 = bytes([0xB5, 0x62, 0x06, 0x24, 0x24, 0x00, 0xFF, 0xFF, 0x06,
-            0x03, 0x00, 0x00, 0x00, 0x00, 0x10, 0x27, 0x00, 0x00,
-            0x05, 0x00, 0xFA, 0x00, 0xFA, 0x00, 0x64, 0x00, 0x2C,
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0xDC])
-        gps_set_success = False
-        
-        while not gps_set_success:
-            self.sendUBX(set_dm6)
-            gps_set_success = self.getUBX_ACK(set_dm6)
+    def __stringifyFakeDate(self, d) :
+        if d :
+            return str(d[1]) + ":" + str(d[2]) + ":" + str(d[0])
+        else :
+            return ''

--- a/python/raspberrypico/lesson-4/README.md
+++ b/python/raspberrypico/lesson-4/README.md
@@ -102,10 +102,10 @@ If you want to generate fake data, use the following syntax for either GPGGA dat
 > :information_source: **TypeError: unexpected keyword argument 'fake'**  
 	The fake data feature was added to the GTU7 module in an update. If you encounter the unexpected argument error, follow the steps earlier in the lesson on installing the GTU7 driver, ensuring you are using the latest copy of the driver located in this project.
 
-    ```python
-    gpgga_data = gps_module.gpgga(fake=True)
-    gprmc_data = gps_module.gprmc(fake=True)
-    ```
+```python
+gpgga_data = gps_module.gpgga(fake=True)
+gprmc_data = gps_module.gprmc(fake=True)
+```
 
 
 **Congratulations! You have successfully completed Lesson 4.**

--- a/python/raspberrypico/lesson-4/README.md
+++ b/python/raspberrypico/lesson-4/README.md
@@ -102,7 +102,7 @@ If you want to generate fake data, use the following syntax for either GPGGA dat
 > :information_source: **TypeError: unexpected keyword argument 'fake'**  
 	The fake data feature was added to the GTU7 module in an update. If you encounter the unexpected argument error, follow the steps earlier in the lesson on installing the GTU7 driver, ensuring you are using the latest copy of the driver located in this project.
 
-    ```
+    ```python
     gpgga_data = gps_module.gpgga(fake=True)
     gprmc_data = gps_module.gprmc(fake=True)
     ```

--- a/python/raspberrypico/lesson-4/README.md
+++ b/python/raspberrypico/lesson-4/README.md
@@ -99,7 +99,7 @@ In some locations, such as the center of a building or in a basement, the GPS mo
 
 If you want to generate fake data, use the following syntax for either GPGGA data or GPRMC data. Note the use of `fake=True` being passed in.
 
-> :information_source: **Unexpected keyward argument 'fake'**  
+> :information_source: **TypeError: unexpected keyword argument 'fake'**  
 	The fake data feature was added to the GTU7 module in an update. If you encounter the unexpected argument error, follow the steps earlier in the lesson on installing the GTU7 driver, ensuring you are using the latest copy of the driver located in this project.
 
     ```

--- a/python/raspberrypico/lesson-4/README.md
+++ b/python/raspberrypico/lesson-4/README.md
@@ -93,6 +93,21 @@ The steps in this section will use the previous hardware and driver sections to 
     Time:		 18:46:14
     ```
 
+#### Is Your GPS Module Not Connecting?
+
+In some locations, such as the center of a building or in a basement, the GPS module cannot receive a GPS signal. To aid in these scenarios, an update was made to the GTU7 module to support "fake" data returned similar to real data. This can be useful for testing purposes, or to gain familiarity with what to expect as a response.
+
+If you want to generate fake data, use the following syntax for either GPGGA data or GPRMC data. Note the use of `fake=True` being passed in.
+
+> :information_source: **Unexpected keyward argument 'fake'**  
+	The fake data feature was added to the GTU7 module in an update. If you encounter the unexpected argument error, follow the steps earlier in the lesson on installing the GTU7 driver, ensuring you are using the latest copy of the driver located in this project.
+
+    ```
+    gpgga_data = gps_module.gpgga(fake=True)
+    gprmc_data = gps_module.gprmc(fake=True)
+    ```
+
+
 **Congratulations! You have successfully completed Lesson 4.**
 
 <br><br>
@@ -200,6 +215,17 @@ if __name__ == "__main__" :
     Traceback (most recent call last):
       File "<stdin>", line 22, in <module>
     IndexError: list index out of range
+    ```
+
+* `ERROR: TypeError: unexpected keyword argument 'fake'`
+    
+    On occasion the drivers will be updated. The GTU7 driver received an update that allowed fake data to be created in the scenario where GPS signal cannot be acquired. If the user attempts to pass in `fake=True` and receives this error, the GTU7 driver is out of date. Follow the steps in the lesson above to install the GTU7 driver, overwriting the existing version on your Pi Pico.
+
+    Example error message:
+    ```sh
+    Traceback (most recent call last):
+      File "<stdin>", line 19, in <module>
+    TypeError: unexpected keyword argument 'fake'
     ```
 
 ## Need help?


### PR DESCRIPTION
* Added `fake=True` option to GPGGA and GPRMC endpoints in the GTU7 module related to https://github.com/StateFarm-STEM/hablogger/issues/104. This will allow students to use fake data should there be issues with the GPS module receiving a GPS signal. *NOTE* This update requires students to pull in the latest GTU7 driver, which is included in the Lesson 4 steps.
* Updated documentation to reflect the new feature.